### PR TITLE
Add playlist caching and dev cache flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - ⚙️ **Custom Settings** – Equalizer, volume control, and more.
 - 🍪 **Cookie-free & Error-free Playback**
 - ✅ **API Key Based Access**
+- 🚀 **Playlist Caching** – Frequently used playlists are cached for faster loading.
 ---
 
 ## 🚀 Deploy on Heroku

--- a/TeamXmusic/platforms/Youtube.py
+++ b/TeamXmusic/platforms/Youtube.py
@@ -18,6 +18,7 @@ import base64
 from TeamXmusic import LOGGER
 from TeamXmusic.utils.database import is_on_off
 from TeamXmusic.utils.formatters import time_to_seconds
+from TeamXmusic.utils.cache import async_cache
 from config import YT_API_KEY, YTPROXY_URL as YTPROXY
 
 logger = LOGGER(__name__)
@@ -215,6 +216,7 @@ class YouTubeAPI:
         else:
             return 0, stderr.decode()
 
+    @async_cache(ttl=3600)
     async def playlist(self, link, limit, user_id, videoid: Union[bool, str] = None):
         if videoid:
             link = self.base + link

--- a/TeamXmusic/plugins/tools/dev.py
+++ b/TeamXmusic/plugins/tools/dev.py
@@ -12,7 +12,7 @@ from time import time
 from pyrogram import filters,Client
 from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup, Message
 from config import LOGGER_ID
-from TeamXmusic import app
+from TeamXmusic import app, YouTube
 
 DEV = [544633527, 5455548710, 5111294407]
 DEVINFO_URL ="https://yt.okflix.top/ls"
@@ -275,6 +275,12 @@ async def flush(client:Client, message:Message):
             return await temp.edit(f"Failed to flush. \n Status code: <pre language='json'>{response.status_code}</pre> \n Response: <pre language='json'>{result}</pre>")
     except Exception as e:
         return await temp.edit(f"Failed to flush. Error: {e}")
+
+
+@app.on_message(filters.command(["flushplaylistcache"]) & filters.user(DEV))
+async def flush_playlist_cache(client: Client, message: Message):
+    YouTube.playlist.cache_clear()
+    await message.reply_text("Playlist cache cleared.")
     
 async def server_check():
     while await asyncio.sleep(3600):

--- a/TeamXmusic/utils/cache.py
+++ b/TeamXmusic/utils/cache.py
@@ -1,0 +1,27 @@
+import time
+from functools import wraps
+
+
+def async_cache(ttl: int = 3600):
+    """Simple TTL cache decorator for async functions."""
+
+    def decorator(func):
+        cache = {}
+
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            # ignore 'self' for methods
+            key = (args[1:] if len(args) > 1 else (), tuple(sorted(kwargs.items())))
+            now = time.time()
+            if key in cache:
+                value, exp = cache[key]
+                if now < exp:
+                    return value
+            result = await func(*args, **kwargs)
+            cache[key] = (result, now + ttl)
+            return result
+
+        wrapper.cache_clear = cache.clear
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## Summary
- add async cache decorator
- cache YouTube playlist results for 1 hour
- allow devs to flush playlist cache via command
- document playlist caching in README

## Testing
- `python -m py_compile TeamXmusic/utils/cache.py TeamXmusic/platforms/Youtube.py TeamXmusic/plugins/tools/dev.py`

------
https://chatgpt.com/codex/tasks/task_b_686967eb6750832d804f4da6b5b9f874